### PR TITLE
Add the ability to use number keys on homepage

### DIFF
--- a/Extension/injection/js/homepage.js
+++ b/Extension/injection/js/homepage.js
@@ -1,0 +1,36 @@
+// Grab this semesters units assuming they are the first on the page
+const units = document
+  .querySelector('.card-text,.content,.mt-3')
+  .querySelector('ul')
+  .querySelectorAll('li');
+
+// To store the a elements of the units and their position in the list
+const unitsShortcutMap = {};
+
+units.forEach((li, i) => {
+  unitsShortcutMap[i + 1] = li.querySelector('a');
+});
+
+function openUnit(aElem) {
+  // Some visual feedback for which unit was chosen
+  aElem.focus();
+
+  window.open(aElem.href, '_blank').focus();
+
+  // Remove the focus
+  aElem.blur();
+}
+
+function keyHandler(event) {
+  //   Don't trigger if modifier keys are pressed
+  if (event.metaKey || event.shiftKey || event.ctrlKey || event.altKey) {
+    return;
+  }
+
+  const unitNumber = Number(event.key);
+  if (unitsShortcutMap[unitNumber] !== undefined) {
+    openUnit(unitsShortcutMap[unitNumber]);
+  }
+}
+
+document.addEventListener('keyup', keyHandler);

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -3,10 +3,6 @@
     "description": "Macquarie Essentials Extension: The ultimate solution for all your MQ Platform annoyances.",
     "version": "0.0.3",
     "manifest_version": 2,
-    "action": {
-        "default_icon": "internal/images/icon128.png",
-        "default_popup": "internal/html/options.html"
-    },
     "browser_action": {
         "default_icon": "internal/images/icon128.png",
         "default_title": "MQEE",

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -3,6 +3,10 @@
     "description": "Macquarie Essentials Extension: The ultimate solution for all your MQ Platform annoyances.",
     "version": "0.0.3",
     "manifest_version": 2,
+    "action": {
+        "default_icon": "internal/images/icon128.png",
+        "default_popup": "internal/html/options.html"
+    },
     "browser_action": {
         "default_icon": "internal/images/icon128.png",
         "default_title": "MQEE",

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -30,6 +30,7 @@
         },
         {
             "matches": ["https://ilearn.mq.edu.au/my/*"],
+            "js": ["/injection/js/homepage.js"],
             "css": ["/injection/css/headerfix.css"]
         },
         {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The latest version of MQEE solves the issues listed below.
 - The MQ logo on the navigation bar is inlined instead of hanging off the edge.
 - The extra header bar on the "My Home" page is now removed.
 - Using the shortcuts Shift++ and Shift+-, you can open or close all collapsibles on an iLearn course page.
+- Pressing the numbers 1-9 on the home page will open the corresponding unit in a new tab.
 
 <h4>eStudent</h4>
 


### PR DESCRIPTION
Adds the ability to press the numbers 1-9 on the homepage to open the corresponding unit for the current semester in a new tab.