### PR TITLE
Remove unsupported action key from manifest

### DIFF
--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -3,10 +3,6 @@
     "description": "Macquarie Essentials Extension: The ultimate solution for all your MQ Platform annoyances.",
     "version": "0.0.3",
     "manifest_version": 2,
-    "action": {
-        "default_icon": "internal/images/icon128.png",
-        "default_popup": "internal/html/options.html"
-    },
     "browser_action": {
         "default_icon": "internal/images/icon128.png",
         "default_title": "MQEE",


### PR DESCRIPTION
This key is not supported by Firefox and causes the extension logo to not sure in the toolbar

<img width="82" alt="Screen Shot 2021-08-16 at 9 14 19 pm" src="https://user-images.githubusercontent.com/36979824/129555248-06451a33-7c70-4ab0-a6bd-77d5e93d0b29.png">
